### PR TITLE
Fix README documentation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Prerequisite for compiling F# to Python using Fable:
 To use the `Fable.Python` library in your Fable project:
 
 ```sh
-> dotnet package add Fable.Python
+> dotnet add package Fable.Python
 ```
 
 ## Usage


### PR DESCRIPTION
This is a minor issue, but as I was setting up a project and noticed that the command `dotnet package add ` should actually be `dotnet add package`.