### PR TITLE
Tool correct name to use in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ let result = json.dumps object
 To compile an F# Fable project to Python run e.g:
 
 ```sh
-> dotnet fable-py MyProject.fsproj
+> fable-py MyProject.fsproj
 ```
 
 For more examples see the


### PR DESCRIPTION
After getting the tool, `dotnet fable-py` is not found, but `fable-py` is, so I guess that's the right one?