### PR TITLE
Relax FSharp.Core requirement

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -4,7 +4,7 @@ source https://api.nuget.org/v3/index.json
 storage: none
 framework: net6.0, netstandard2.0, netstandard2.1
 
-nuget FSharp.Core ~> 4.7
+nuget FSharp.Core >= 4.7.2
 nuget Fable.Core >= 4.0.0-snake-island-alpha-007
 
 group Test


### PR DESCRIPTION
Using `FSharp.Core ~> 4.7` means `FSharp.Core >= 4.7.2 && FSharp.Core < 5.0.0` 

I don't believe Fable.Python needs this strict requirement, especially since F# 6.0 project already pull in FSharp.Core >= 6.0 so this PR relaxes this version requirement to make it just >= 4.7.2 which allows for wide compatibility with Fable projects

> Noticed this from the dependencies of Fable.SimpleJson.Python