### PR TITLE
add sys.exit

### DIFF
--- a/src/stdlib/Sys.fs
+++ b/src/stdlib/Sys.fs
@@ -28,6 +28,15 @@ type IExports =
     abstract prefix: string
     abstract version: string
     abstract version_info: VersionInfo
+    /// Exits with code 0, indicating success
+    /// See https://docs.python.org/3/library/sys.html#sys.exit
+    abstract exit: unit -> 'a
+    /// Exits with provided status
+    /// See https://docs.python.org/3/library/sys.html#sys.exit
+    abstract exit: status: int -> 'a
+    /// Exits with exit status 1, printing message to stderr
+    /// See https://docs.python.org/3/library/sys.html#sys.exit
+    abstract exit: message: string -> 'a
 
 /// System-specific parameters and functions
 [<ImportAll("sys")>]


### PR DESCRIPTION
This adds `sys.exit` https://docs.python.org/3/library/sys.html#sys.exit, using overloads for the three common ways of calling the method. The return type is polymorphic to represent it never returning, allowing it to be used in place of a value of any type.